### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/publish_docker_docker.yml
+++ b/.github/workflows/publish_docker_docker.yml
@@ -9,7 +9,7 @@ jobs:
     - uses: actions/checkout@v1
 
     - name: Publish to Docker Package Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       id: docker
       with:
         name: futureman/github-action-trellis


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore